### PR TITLE
Forward compatibility with react/event-loop 1.0 while still supporting 0.5 and 0.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "clue/block-react": "^1.3",
     "clue/buzz-react": "^2.3",
     "react/promise": "^2.7",
-    "react/event-loop": "^0.4.3||^0.5.2"
+    "react/event-loop": "^0.4.3||^0.5.2||^1.0"
   },
   "autoload": {
     "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -1,10 +1,10 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "fb2426192473764ffc1786e23a191bff",
+    "content-hash": "4d3d51eee4d7ca027f02c276ba84104b",
     "packages": [
         {
             "name": "clue/block-react",


### PR DESCRIPTION
Last Juli we released event-loop[`v1.0.0`](https://github.com/reactphp/event-loop/releases/tag/v1.0.0) which is essentially a retag of 0.5. This PR includes it in your `composer.json` so it doesn't create conflicts a long the way.